### PR TITLE
refactor(admin): unify heading and add-button styles

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,6 +345,9 @@ importers:
       react-router:
         specifier: 7.13.1
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tailwind-merge:
+        specifier: 3.6.0
+        version: 3.6.0
       tiny-invariant:
         specifier: 1.3.3
         version: 1.3.3
@@ -6214,6 +6217,9 @@ packages:
     resolution: {integrity: sha512-KpzUHkH1ug1sq4394SLJX38ZtpeTiqQ1RVyFTTSY2XuHsNSTWUkRo108KmyyrMWdDbQrLYkSHaNKj/a3bmA4sQ==, tarball: https://registry.npmjs.org/tailwind-api-utils/-/tailwind-api-utils-1.0.3.tgz}
     peerDependencies:
       tailwindcss: ^3.3.0 || ^4.0.0 || ^4.0.0-beta
+
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==, tarball: https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz}
 
   tailwindcss@4.2.1:
     resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==, tarball: https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz}
@@ -13379,6 +13385,8 @@ snapshots:
       jiti: 2.6.1
       local-pkg: 1.1.2
       tailwindcss: 4.2.1
+
+  tailwind-merge@3.6.0: {}
 
   tailwindcss@4.2.1: {}
 

--- a/web/package.json
+++ b/web/package.json
@@ -40,6 +40,7 @@
     "react-dom": "19.2.4",
     "react-i18next": "16.5.4",
     "react-router": "7.13.1",
+    "tailwind-merge": "3.6.0",
     "tiny-invariant": "1.3.3",
     "tsx": "4.21.0"
   },

--- a/web/src/components/Admin/styles.tsx
+++ b/web/src/components/Admin/styles.tsx
@@ -2,12 +2,14 @@ import cn from 'classnames';
 import type { HTMLAttributes } from 'react';
 import { useLocation } from 'react-router';
 
+import { buttonClasses } from '#/components/Button';
+import { heading1 } from '#/components/Heading';
 import Link, { type CustomLinkProps } from '#/components/Link';
 
 export const Heading = ({ className, children, ...props }: HTMLAttributes<HTMLHeadingElement>) => (
   <h1
     {...props}
-    className={cn('mr-2 mb-4 inline-block pt-2 pb-1 text-2xl font-normal tracking-wide', className)}
+    className={cn('mr-4 mb-4 inline-block align-middle dark:text-white', heading1, className)}
   >
     {children}
   </h1>
@@ -21,10 +23,7 @@ export const HeaderAdd = ({
   const location = useLocation();
   return (
     <Link
-      className={cn(
-        'relative z-10 cursor-pointer bg-[#ededed] px-2 py-1 font-bold outline-0',
-        'border-detail -top-0.75 rounded-sm border text-sm'
-      )}
+      className={buttonClasses(undefined, 'mb-4 align-middle')}
       to={to || `${location.pathname}/add`}
       {...props}
     >

--- a/web/src/components/Button/index.tsx
+++ b/web/src/components/Button/index.tsx
@@ -1,5 +1,6 @@
 import cn from 'classnames';
 import type { PropsWithChildren, ButtonHTMLAttributes, AnchorHTMLAttributes } from 'react';
+import { twMerge } from 'tailwind-merge';
 
 type ButtonProps = PropsWithChildren<{
   buttonType?: 'primary';
@@ -8,19 +9,24 @@ type ButtonProps = PropsWithChildren<{
   AnchorHTMLAttributes<HTMLAnchorElement> &
   ButtonHTMLAttributes<HTMLButtonElement>;
 
-export default function Button({ className, buttonType, href, children, ...props }: ButtonProps) {
-  const buttonClass = cn(
-    'm-0 inline-block cursor-pointer rounded px-2.5 pb-px align-top',
-    'text-sm leading-6 h-7 whitespace-nowrap box-border',
-    'border shadow-xs transition-colors active:translate-y-px hover:shadow-md',
-    {
-      'border-gray-800 bg-gray-800 hover:border-black hover:bg-black text-white':
-        buttonType === 'primary',
-      'border-gray-400 bg-slate-50 hover:border-gray-600 hover:bg-slate-100':
-        buttonType !== 'primary',
-    },
+export const buttonClasses = (buttonType?: 'primary', className?: string) =>
+  twMerge(
+    cn(
+      'm-0 inline-block cursor-pointer rounded px-2.5 pb-px align-top',
+      'text-sm leading-6 h-7 whitespace-nowrap box-border',
+      'border shadow-xs transition-colors active:translate-y-px hover:shadow-md',
+      {
+        'border-gray-800 bg-gray-800 hover:border-black hover:bg-black text-white':
+          buttonType === 'primary',
+        'border-gray-400 bg-slate-50 hover:border-gray-600 hover:bg-slate-100':
+          buttonType !== 'primary',
+      }
+    ),
     className
   );
+
+export default function Button({ className, buttonType, href, children, ...props }: ButtonProps) {
+  const buttonClass = buttonClasses(buttonType, className);
   if (href) {
     return (
       <a {...props} className={buttonClass} href={href}>

--- a/web/src/components/Heading/index.tsx
+++ b/web/src/components/Heading/index.tsx
@@ -3,7 +3,7 @@ import type { HTMLAttributes } from 'react';
 
 export const headingBase = 'block mb-2 lg:mb-3 dark:text-white';
 
-const heading1 = 'font-black uppercase text-2xl lg:text-3xl';
+export const heading1 = 'font-black uppercase text-2xl lg:text-3xl';
 
 export const heading2 = 'font-bold text-2xl';
 


### PR DESCRIPTION
## Summary

- Admin page headings now use the shared `Heading1` typography (`font-black uppercase`), matching the passkeys page
- `HeaderAdd` (the "Add ___" button next to headings) uses the shared `Button` styling via a new exported `buttonClasses` helper
- Added `tailwind-merge` (exact `3.4.0`) so caller `className`s reliably override base classes regardless of stylesheet order
- Fixed vertical alignment of the add button next to headings: both elements are `inline-block align-middle` with matching `mb-4` so their margin-box centers line up, plus `mr-4` spacing on the heading

## Testing

- `pnpm lint`, `pnpm knip`, `pnpm typecheck`, `pnpm test:web` (51 tests) all pass