### PR TITLE
refactor(admin): polish navigation and form controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "observability:dev:podman": "bash observability/dev.sh podman",
     "build": "pnpm --filter @highforthis/shared build && pnpm --filter @highforthis/graphql build:service && pnpm --filter @highforthis/web build:service",
     "knip": "knip",
-    "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint --report-unused-disable-directives .",
+    "lint": "eslint --cache --cache-strategy content --cache-location ./node_modules/.cache/eslint --report-unused-disable-directives .",
     "lint-fix": "pnpm lint --fix",
     "test:web": "pnpm --filter @highforthis/web test",
     "test:web:watch": "pnpm --filter @highforthis/web test:watch",

--- a/web/src/components/Admin/NavMenu/index.tsx
+++ b/web/src/components/Admin/NavMenu/index.tsx
@@ -162,7 +162,7 @@ function Brand({ isCollapsed }: { isCollapsed: boolean }) {
           {t('title').charAt(0)}
         </span>
       ) : (
-        <span className="font-title truncate text-base tracking-tight text-neutral-900 uppercase dark:text-white">
+        <span className="font-title truncate text-2xl tracking-tight text-neutral-900 uppercase dark:text-white">
           {t('title')}
         </span>
       )}

--- a/web/src/components/Form/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/web/src/components/Form/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -2,13 +2,13 @@
 
 exports[`select > add className 1`] = `
 <select
-  class="my-1 mr-1 last:mr-0 rounded-md border-gray-300 shadow-xs focus:border-pink focus:ring-3 focus:ring-pink-200 focus:ring-opacity-50 transition-colors foo"
+  class="my-1 mr-1 last:mr-0 focus:border-pink focus:ring-3 focus:ring-opacity-50 transition-colors h-9 rounded-lg border-neutral-300 bg-white py-0 pr-9 text-sm shadow-xs dark:bg-surface-dark-elevated hover:border-neutral-400 dark:border-white/10 dark:text-white foo"
 />
 `;
 
 exports[`select > child nodes > children 1`] = `
 <select
-  class="my-1 mr-1 last:mr-0 rounded-md border-gray-300 shadow-xs focus:border-pink focus:ring-3 focus:ring-pink-200 focus:ring-opacity-50 transition-colors"
+  class="my-1 mr-1 last:mr-0 focus:border-pink focus:ring-3 focus:ring-opacity-50 transition-colors h-9 rounded-lg border-neutral-300 bg-white py-0 pr-9 text-sm shadow-xs dark:bg-surface-dark-elevated hover:border-neutral-400 dark:border-white/10 dark:text-white"
 >
   <option
     value="meximelt"
@@ -20,7 +20,7 @@ exports[`select > child nodes > children 1`] = `
 
 exports[`select > child nodes > children with choices 1`] = `
 <select
-  class="my-1 mr-1 last:mr-0 rounded-md border-gray-300 shadow-xs focus:border-pink focus:ring-3 focus:ring-pink-200 focus:ring-opacity-50 transition-colors"
+  class="my-1 mr-1 last:mr-0 focus:border-pink focus:ring-3 focus:ring-opacity-50 transition-colors h-9 rounded-lg border-neutral-300 bg-white py-0 pr-9 text-sm shadow-xs dark:bg-surface-dark-elevated hover:border-neutral-400 dark:border-white/10 dark:text-white"
 >
   <option
     value="mild"
@@ -47,7 +47,7 @@ exports[`select > child nodes > children with choices 1`] = `
 
 exports[`select > choices > choice 1`] = `
 <select
-  class="my-1 mr-1 last:mr-0 rounded-md border-gray-300 shadow-xs focus:border-pink focus:ring-3 focus:ring-pink-200 focus:ring-opacity-50 transition-colors"
+  class="my-1 mr-1 last:mr-0 focus:border-pink focus:ring-3 focus:ring-opacity-50 transition-colors h-9 rounded-lg border-neutral-300 bg-white py-0 pr-9 text-sm shadow-xs dark:bg-surface-dark-elevated hover:border-neutral-400 dark:border-white/10 dark:text-white"
 >
   <option
     value="mild"
@@ -69,7 +69,7 @@ exports[`select > choices > choice 1`] = `
 
 exports[`select > choices > choices 1`] = `
 <select
-  class="my-1 mr-1 last:mr-0 rounded-md border-gray-300 shadow-xs focus:border-pink focus:ring-3 focus:ring-pink-200 focus:ring-opacity-50 transition-colors"
+  class="my-1 mr-1 last:mr-0 focus:border-pink focus:ring-3 focus:ring-opacity-50 transition-colors h-9 rounded-lg border-neutral-300 bg-white py-0 pr-9 text-sm shadow-xs dark:bg-surface-dark-elevated hover:border-neutral-400 dark:border-white/10 dark:text-white"
 >
   <option
     value="Mild"
@@ -91,7 +91,7 @@ exports[`select > choices > choices 1`] = `
 
 exports[`select > choices > choices as objects 1`] = `
 <select
-  class="my-1 mr-1 last:mr-0 rounded-md border-gray-300 shadow-xs focus:border-pink focus:ring-3 focus:ring-pink-200 focus:ring-opacity-50 transition-colors"
+  class="my-1 mr-1 last:mr-0 focus:border-pink focus:ring-3 focus:ring-opacity-50 transition-colors h-9 rounded-lg border-neutral-300 bg-white py-0 pr-9 text-sm shadow-xs dark:bg-surface-dark-elevated hover:border-neutral-400 dark:border-white/10 dark:text-white"
 >
   <option
     value="mild"
@@ -113,13 +113,13 @@ exports[`select > choices > choices as objects 1`] = `
 
 exports[`select > empty 1`] = `
 <select
-  class="my-1 mr-1 last:mr-0 rounded-md border-gray-300 shadow-xs focus:border-pink focus:ring-3 focus:ring-pink-200 focus:ring-opacity-50 transition-colors"
+  class="my-1 mr-1 last:mr-0 focus:border-pink focus:ring-3 focus:ring-opacity-50 transition-colors h-9 rounded-lg border-neutral-300 bg-white py-0 pr-9 text-sm shadow-xs dark:bg-surface-dark-elevated hover:border-neutral-400 dark:border-white/10 dark:text-white"
 />
 `;
 
 exports[`select > groups > no value 1`] = `
 <select
-  class="my-1 mr-1 last:mr-0 rounded-md border-gray-300 shadow-xs focus:border-pink focus:ring-3 focus:ring-pink-200 focus:ring-opacity-50 transition-colors"
+  class="my-1 mr-1 last:mr-0 focus:border-pink focus:ring-3 focus:ring-opacity-50 transition-colors h-9 rounded-lg border-neutral-300 bg-white py-0 pr-9 text-sm shadow-xs dark:bg-surface-dark-elevated hover:border-neutral-400 dark:border-white/10 dark:text-white"
 >
   <optgroup
     label="Tacos"
@@ -159,7 +159,7 @@ exports[`select > groups > no value 1`] = `
 
 exports[`select > groups > value 1`] = `
 <select
-  class="my-1 mr-1 last:mr-0 rounded-md border-gray-300 shadow-xs focus:border-pink focus:ring-3 focus:ring-pink-200 focus:ring-opacity-50 transition-colors"
+  class="my-1 mr-1 last:mr-0 focus:border-pink focus:ring-3 focus:ring-opacity-50 transition-colors h-9 rounded-lg border-neutral-300 bg-white py-0 pr-9 text-sm shadow-xs dark:bg-surface-dark-elevated hover:border-neutral-400 dark:border-white/10 dark:text-white"
 >
   <optgroup
     label="Tacos"
@@ -199,7 +199,7 @@ exports[`select > groups > value 1`] = `
 
 exports[`select > groups > values 1`] = `
 <select
-  class="my-1 mr-1 last:mr-0 rounded-md border-gray-300 shadow-xs focus:border-pink focus:ring-3 focus:ring-pink-200 focus:ring-opacity-50 transition-colors"
+  class="my-1 mr-1 last:mr-0 focus:border-pink focus:ring-3 focus:ring-opacity-50 transition-colors h-9 rounded-lg border-neutral-300 bg-white py-0 pr-9 text-sm shadow-xs dark:bg-surface-dark-elevated hover:border-neutral-400 dark:border-white/10 dark:text-white"
   multiple=""
 >
   <optgroup
@@ -240,41 +240,41 @@ exports[`select > groups > values 1`] = `
 
 exports[`select > multiple > false 1`] = `
 <select
-  class="my-1 mr-1 last:mr-0 rounded-md border-gray-300 shadow-xs focus:border-pink focus:ring-3 focus:ring-pink-200 focus:ring-opacity-50 transition-colors"
+  class="my-1 mr-1 last:mr-0 focus:border-pink focus:ring-3 focus:ring-opacity-50 transition-colors h-9 rounded-lg border-neutral-300 bg-white py-0 pr-9 text-sm shadow-xs dark:bg-surface-dark-elevated hover:border-neutral-400 dark:border-white/10 dark:text-white"
 />
 `;
 
 exports[`select > multiple > falsey 1`] = `
 <select
-  class="my-1 mr-1 last:mr-0 rounded-md border-gray-300 shadow-xs focus:border-pink focus:ring-3 focus:ring-pink-200 focus:ring-opacity-50 transition-colors"
+  class="my-1 mr-1 last:mr-0 focus:border-pink focus:ring-3 focus:ring-opacity-50 transition-colors h-9 rounded-lg border-neutral-300 bg-white py-0 pr-9 text-sm shadow-xs dark:bg-surface-dark-elevated hover:border-neutral-400 dark:border-white/10 dark:text-white"
   multiple=""
 />
 `;
 
 exports[`select > multiple > string 1`] = `
 <select
-  class="my-1 mr-1 last:mr-0 rounded-md border-gray-300 shadow-xs focus:border-pink focus:ring-3 focus:ring-pink-200 focus:ring-opacity-50 transition-colors"
+  class="my-1 mr-1 last:mr-0 focus:border-pink focus:ring-3 focus:ring-opacity-50 transition-colors h-9 rounded-lg border-neutral-300 bg-white py-0 pr-9 text-sm shadow-xs dark:bg-surface-dark-elevated hover:border-neutral-400 dark:border-white/10 dark:text-white"
   multiple=""
 />
 `;
 
 exports[`select > multiple > true 1`] = `
 <select
-  class="my-1 mr-1 last:mr-0 rounded-md border-gray-300 shadow-xs focus:border-pink focus:ring-3 focus:ring-pink-200 focus:ring-opacity-50 transition-colors"
+  class="my-1 mr-1 last:mr-0 focus:border-pink focus:ring-3 focus:ring-opacity-50 transition-colors h-9 rounded-lg border-neutral-300 bg-white py-0 pr-9 text-sm shadow-xs dark:bg-surface-dark-elevated hover:border-neutral-400 dark:border-white/10 dark:text-white"
   multiple=""
 />
 `;
 
 exports[`select > multiple > truthy 1`] = `
 <select
-  class="my-1 mr-1 last:mr-0 rounded-md border-gray-300 shadow-xs focus:border-pink focus:ring-3 focus:ring-pink-200 focus:ring-opacity-50 transition-colors"
+  class="my-1 mr-1 last:mr-0 focus:border-pink focus:ring-3 focus:ring-opacity-50 transition-colors h-9 rounded-lg border-neutral-300 bg-white py-0 pr-9 text-sm shadow-xs dark:bg-surface-dark-elevated hover:border-neutral-400 dark:border-white/10 dark:text-white"
   multiple=""
 />
 `;
 
 exports[`select > placeholder > choices 1`] = `
 <select
-  class="my-1 mr-1 last:mr-0 rounded-md border-gray-300 shadow-xs focus:border-pink focus:ring-3 focus:ring-pink-200 focus:ring-opacity-50 transition-colors"
+  class="my-1 mr-1 last:mr-0 focus:border-pink focus:ring-3 focus:ring-opacity-50 transition-colors h-9 rounded-lg border-neutral-300 bg-white py-0 pr-9 text-sm shadow-xs dark:bg-surface-dark-elevated hover:border-neutral-400 dark:border-white/10 dark:text-white"
 >
   <option
     value=""
@@ -301,7 +301,7 @@ exports[`select > placeholder > choices 1`] = `
 
 exports[`select > placeholder > choices as objects 1`] = `
 <select
-  class="my-1 mr-1 last:mr-0 rounded-md border-gray-300 shadow-xs focus:border-pink focus:ring-3 focus:ring-pink-200 focus:ring-opacity-50 transition-colors"
+  class="my-1 mr-1 last:mr-0 focus:border-pink focus:ring-3 focus:ring-opacity-50 transition-colors h-9 rounded-lg border-neutral-300 bg-white py-0 pr-9 text-sm shadow-xs dark:bg-surface-dark-elevated hover:border-neutral-400 dark:border-white/10 dark:text-white"
 >
   <option
     value=""
@@ -328,7 +328,7 @@ exports[`select > placeholder > choices as objects 1`] = `
 
 exports[`select > placeholder > no choices 1`] = `
 <select
-  class="my-1 mr-1 last:mr-0 rounded-md border-gray-300 shadow-xs focus:border-pink focus:ring-3 focus:ring-pink-200 focus:ring-opacity-50 transition-colors"
+  class="my-1 mr-1 last:mr-0 focus:border-pink focus:ring-3 focus:ring-opacity-50 transition-colors h-9 rounded-lg border-neutral-300 bg-white py-0 pr-9 text-sm shadow-xs dark:bg-surface-dark-elevated hover:border-neutral-400 dark:border-white/10 dark:text-white"
 >
   <option
     value=""

--- a/web/src/components/Form/Select/index.tsx
+++ b/web/src/components/Form/Select/index.tsx
@@ -1,5 +1,5 @@
-import cn from 'classnames';
 import type { SelectHTMLAttributes, ChangeEvent } from 'react';
+import { twMerge } from 'tailwind-merge';
 
 import { inputBase } from '#/components/Form/styles';
 
@@ -56,7 +56,12 @@ export default function Select({
       onChange={onChange}
       defaultValue={value}
       multiple={multipleProp ? Boolean(multipleProp) : false}
-      className={cn(inputBase, className)}
+      className={twMerge(
+        inputBase,
+        'h-9 rounded-lg border-neutral-300 bg-white py-0 pr-9 text-sm shadow-xs',
+        'dark:bg-surface-dark-elevated hover:border-neutral-400 dark:border-white/10 dark:text-white',
+        className
+      )}
     >
       {placeholder && (
         <option key={placeholder} value="">

--- a/web/src/routes/admin/layout.tsx
+++ b/web/src/routes/admin/layout.tsx
@@ -72,7 +72,7 @@ function AdminShell() {
           )}
         >
           <NavMenu.MobileToggle />
-          <span className="font-title truncate text-base tracking-tight text-neutral-900 uppercase dark:text-white">
+          <span className="font-title truncate text-2xl tracking-tight text-neutral-900 uppercase dark:text-white">
             {t('title')}
           </span>
         </header>

--- a/web/src/routes/admin/media/index.tsx
+++ b/web/src/routes/admin/media/index.tsx
@@ -98,7 +98,6 @@ export default function Media({ loaderData }: Route.ComponentProps) {
     <>
       <Select
         key="type"
-        className="mx-2"
         placeholder={t('media.selectMediaType')}
         value={searchParams.get('type') || ''}
         choices={uploads?.types?.map((type: string) => ({
@@ -109,7 +108,6 @@ export default function Media({ loaderData }: Route.ComponentProps) {
       />
       <Select
         key="mimeType"
-        className="mx-2"
         placeholder={t('media.selectMimeType')}
         value={searchParams.get('mimeType') || ''}
         choices={uploads?.mimeTypes || []}


### PR DESCRIPTION
## Summary

- enlarge the admin site title to `text-2xl` in the sidebar, drawer, and mobile header
- refresh shared select controls with consistent sizing, borders, hover states, and dark-mode styling
- clean up redundant spacing around the media filters
- use ESLint's content-based cache strategy

## Testing

- `pnpm lint`
- `pnpm knip`
- `pnpm typecheck`
- `pnpm test:web` (51 tests)