### PR TITLE
Add OpenObserve RUM to web

### DIFF
--- a/observability/README.md
+++ b/observability/README.md
@@ -43,6 +43,29 @@ OTEL_SDK_DISABLED=false
 
 If `OTEL_EXPORTER_OTLP_ENDPOINT` is absent, the services continue to emit structured JSON logs to stdout but do not initialize OpenTelemetry exporters. Set `OTEL_SDK_DISABLED=true` to explicitly disable exporting.
 
+## Configure browser RUM
+
+In OpenObserve, open the RUM ingestion setup and create an application for the web frontend. Configure the following variables on the Railway `web` service using the values from the generated browser SDK configuration:
+
+```text
+OPENOBSERVE_RUM_APPLICATION_ID=<application ID>
+OPENOBSERVE_RUM_CLIENT_TOKEN=<browser client token>
+OPENOBSERVE_RUM_SITE=https://<openobserve-domain>
+OPENOBSERVE_RUM_ORGANIZATION_IDENTIFIER=default
+```
+
+The browser client token is public by design. Use a dedicated browser ingestion token; never reuse the root account or the server-side `OTEL_EXPORTER_OTLP_HEADERS` credential. The site may be a hostname or URL, but should point to the OpenObserve server rather than its `/api/...` OTLP endpoint.
+
+RUM collects resources, long tasks, user interactions, browser errors, and same-origin distributed traces. Session replay masks user input and samples 20% of monitored sessions by default. Sampling can be changed independently:
+
+```text
+OPENOBSERVE_RUM_SESSION_SAMPLE_RATE=100
+OPENOBSERVE_RUM_REPLAY_SAMPLE_RATE=20
+OPENOBSERVE_RUM_TRACE_SAMPLE_RATE=100
+```
+
+Each rate must be between `0` and `100`; set the replay rate to `0` to disable session replay. RUM remains disabled when none of its required variables are present, and startup reports an incomplete configuration when only some are set.
+
 ## Run locally
 
 Docker is the default:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,6 +276,12 @@ importers:
       '@lexical/utils':
         specifier: 0.41.0
         version: 0.41.0
+      '@openobserve/browser-logs':
+        specifier: 0.4.1
+        version: 0.4.1(@openobserve/browser-rum@0.4.1)
+      '@openobserve/browser-rum':
+        specifier: 0.4.1
+        version: 0.4.1(@openobserve/browser-logs@0.4.1)
       '@react-router/express':
         specifier: 8.3.0
         version: 8.3.0(express@5.2.1)(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@5.9.3)
@@ -1837,6 +1843,31 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@openobserve/browser-core@0.4.1':
+    resolution: {integrity: sha512-mpotVs/YwFdyqK9DPK5doxQeNtw28N49wW8dsjbhVzoDEDOU1DHfTNiXeb6y7KmK5+UHPM4tsbJ70nbFqByg3Q==, tarball: https://registry.npmjs.org/@openobserve/browser-core/-/browser-core-0.4.1.tgz}
+
+  '@openobserve/browser-logs@0.4.1':
+    resolution: {integrity: sha512-wmPN0IsoghIx3a07Hg6YMz4tmZ95G4zw/9e39l19P32wEVMryErXkMKcEy9XYcmstQKrk2StKYi8x+OEwCTnNg==, tarball: https://registry.npmjs.org/@openobserve/browser-logs/-/browser-logs-0.4.1.tgz}
+    peerDependencies:
+      '@openobserve/browser-rum': 0.4.1
+    peerDependenciesMeta:
+      '@openobserve/browser-rum':
+        optional: true
+
+  '@openobserve/browser-rum-core@0.4.1':
+    resolution: {integrity: sha512-owO27fFiSJHLE7gH0HVTihPWnv1ZMFhym+w/yLikB96Sne+2PNUY5SAAZco56+9309I6H/PqFRRnxpUjGKA+xA==, tarball: https://registry.npmjs.org/@openobserve/browser-rum-core/-/browser-rum-core-0.4.1.tgz}
+
+  '@openobserve/browser-rum@0.4.1':
+    resolution: {integrity: sha512-X+/tcCh6BGzExoy2yT3knGgd0AF+9jODlf0BHdOxhdzieJu05SXm1EbKCHdMZFqLiWUAXXc5Yq4G08Lvmbonvw==, tarball: https://registry.npmjs.org/@openobserve/browser-rum/-/browser-rum-0.4.1.tgz}
+    peerDependencies:
+      '@openobserve/browser-logs': 0.4.1
+    peerDependenciesMeta:
+      '@openobserve/browser-logs':
+        optional: true
+
+  '@openobserve/js-core@0.4.1':
+    resolution: {integrity: sha512-/fZZClT7JmrhENWdtKdYQXF9jBI+2i+SZt+gatJnkov3e1ho88LuOqE4Kt5p72PT7Z4wv/r56fcYWdV20YjKxA==, tarball: https://registry.npmjs.org/@openobserve/js-core/-/js-core-0.4.1.tgz}
 
   '@opentelemetry/api-logs@0.220.0':
     resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==, tarball: https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz}
@@ -8564,6 +8595,32 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@openobserve/browser-core@0.4.1':
+    dependencies:
+      '@openobserve/js-core': 0.4.1
+
+  '@openobserve/browser-logs@0.4.1(@openobserve/browser-rum@0.4.1)':
+    dependencies:
+      '@openobserve/browser-core': 0.4.1
+      '@openobserve/js-core': 0.4.1
+    optionalDependencies:
+      '@openobserve/browser-rum': 0.4.1(@openobserve/browser-logs@0.4.1)
+
+  '@openobserve/browser-rum-core@0.4.1':
+    dependencies:
+      '@openobserve/browser-core': 0.4.1
+      '@openobserve/js-core': 0.4.1
+
+  '@openobserve/browser-rum@0.4.1(@openobserve/browser-logs@0.4.1)':
+    dependencies:
+      '@openobserve/browser-core': 0.4.1
+      '@openobserve/browser-rum-core': 0.4.1
+      '@openobserve/js-core': 0.4.1
+    optionalDependencies:
+      '@openobserve/browser-logs': 0.4.1(@openobserve/browser-rum@0.4.1)
+
+  '@openobserve/js-core@0.4.1': {}
 
   '@opentelemetry/api-logs@0.220.0':
     dependencies:

--- a/web/README.md
+++ b/web/README.md
@@ -28,6 +28,16 @@ pnpm graphql:dev
 | --- | --- |
 | `SERVER_PORT` | Web server port (default: `3000`) |
 | `GQL_HOST` | GraphQL server URL (default: `http://localhost:8081`) |
+| `OPENOBSERVE_RUM_APPLICATION_ID` | OpenObserve RUM application ID; setting any required RUM variable enables browser monitoring |
+| `OPENOBSERVE_RUM_CLIENT_TOKEN` | Browser ingestion token from OpenObserve's RUM setup (this token is intentionally sent to browsers) |
+| `OPENOBSERVE_RUM_SITE` | OpenObserve host or URL, such as `https://openobserve.example.com` |
+| `OPENOBSERVE_RUM_ORGANIZATION_IDENTIFIER` | OpenObserve organization (default: `default`) |
+| `OPENOBSERVE_RUM_SESSION_SAMPLE_RATE` | Percentage of sessions monitored (default: `100`) |
+| `OPENOBSERVE_RUM_REPLAY_SAMPLE_RATE` | Percentage of sessions recorded for replay; use `0` to disable replay (default: `20`) |
+| `OPENOBSERVE_RUM_TRACE_SAMPLE_RATE` | Percentage of same-origin requests correlated with backend traces (default: `100`) |
+| `OPENOBSERVE_RUM_SERVICE` | RUM service name (default: `web`) |
+| `OPENOBSERVE_RUM_ENVIRONMENT` | Deployment environment (defaults to the Railway environment or `NODE_ENV`) |
+| `OPENOBSERVE_RUM_VERSION` | Deployed version (defaults to the Railway Git SHA) |
 
 ## Development
 

--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,8 @@
     "@lexical/rich-text": "0.41.0",
     "@lexical/selection": "0.41.0",
     "@lexical/utils": "0.41.0",
+    "@openobserve/browser-logs": "0.4.1",
+    "@openobserve/browser-rum": "0.4.1",
     "@react-router/express": "8.3.0",
     "@react-router/node": "8.3.0",
     "@simplewebauthn/browser": "13.3.0",

--- a/web/src/__tests__/rum.server.test.ts
+++ b/web/src/__tests__/rum.server.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { getOpenObserveRumConfig } from '../rum.server';
+
+describe('openobserve RUM configuration', () => {
+  it('is disabled when no RUM variables are set', () => {
+    expect(getOpenObserveRumConfig({})).toBeUndefined();
+  });
+
+  it('builds a safe browser configuration', () => {
+    expect(
+      getOpenObserveRumConfig({
+        OPENOBSERVE_RUM_APPLICATION_ID: 'highforthis-web',
+        OPENOBSERVE_RUM_CLIENT_TOKEN: 'client-token',
+        OPENOBSERVE_RUM_SITE: 'http://localhost:5080/api/default',
+        NODE_ENV: 'test',
+      })
+    ).toEqual({
+      applicationId: 'highforthis-web',
+      clientToken: 'client-token',
+      site: 'localhost:5080',
+      organizationIdentifier: 'default',
+      service: 'web',
+      environment: 'test',
+      version: '1.0.0',
+      insecureHTTP: true,
+      sessionSampleRate: 100,
+      sessionReplaySampleRate: 20,
+      traceSampleRate: 100,
+    });
+  });
+
+  it('requires all core variables when RUM is configured', () => {
+    expect(() =>
+      getOpenObserveRumConfig({
+        OPENOBSERVE_RUM_APPLICATION_ID: 'highforthis-web',
+      })
+    ).toThrow('OpenObserve RUM is missing OPENOBSERVE_RUM_CLIENT_TOKEN, OPENOBSERVE_RUM_SITE');
+  });
+
+  it('validates sampling rates', () => {
+    expect(() =>
+      getOpenObserveRumConfig({
+        OPENOBSERVE_RUM_APPLICATION_ID: 'highforthis-web',
+        OPENOBSERVE_RUM_CLIENT_TOKEN: 'client-token',
+        OPENOBSERVE_RUM_SITE: 'openobserve.example.com',
+        OPENOBSERVE_RUM_REPLAY_SAMPLE_RATE: '101',
+      })
+    ).toThrow('OPENOBSERVE_RUM_REPLAY_SAMPLE_RATE must be a number between 0 and 100');
+  });
+});

--- a/web/src/entry.client.tsx
+++ b/web/src/entry.client.tsx
@@ -5,8 +5,22 @@ import { HydratedRouter } from 'react-router/dom';
 
 import createI18n from './i18n.js';
 
+async function startOpenObserveRum() {
+  const config = window.__OPENOBSERVE_RUM__;
+  if (!config) {
+    return;
+  }
+
+  try {
+    const { initializeOpenObserveRum } = await import('./rum.client');
+    initializeOpenObserveRum(config);
+  } catch (error) {
+    console.error('OpenObserve RUM failed to initialize', error);
+  }
+}
+
 (async () => {
-  const i18n = await createI18n('en', false);
+  const [i18n] = await Promise.all([createI18n('en', false), startOpenObserveRum()]);
 
   startTransition(() => {
     hydrateRoot(

--- a/web/src/root.tsx
+++ b/web/src/root.tsx
@@ -17,6 +17,8 @@ import { Html, Body, Boundary, useLayout } from './components/Layout';
 import { TWITTER_USERNAME } from './constants';
 import { graphqlHostContext } from './context.js';
 import { appQuery } from './root.graphql';
+import type { OpenObserveRumConfig } from './rum';
+import { getOpenObserveRumConfig } from './rum.server';
 import type { AppQuery } from './types/graphql';
 import { createClientCache } from './utils/cache';
 import query from './utils/query';
@@ -47,6 +49,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     data,
     isAuthenticated: Boolean(user),
     graphqlHost: context.get(graphqlHostContext),
+    openObserveRum: getOpenObserveRumConfig(),
   };
 }
 
@@ -85,8 +88,23 @@ const AppLinks = ({ data }: { data: AppQuery }) => {
   );
 };
 
+const OpenObserveRumConfigScript = ({ config }: { config?: OpenObserveRumConfig }) => {
+  if (!config) {
+    return null;
+  }
+
+  const serializedConfig = JSON.stringify(config).replace(/</g, '\\u003c');
+  return (
+    <script
+      dangerouslySetInnerHTML={{
+        __html: `window.__OPENOBSERVE_RUM__=${serializedConfig};`,
+      }}
+    />
+  );
+};
+
 export default function Root({ loaderData }: Route.ComponentProps) {
-  const { data } = loaderData;
+  const { data, openObserveRum } = loaderData;
   const layout = useLayout();
   return (
     <Html>
@@ -97,6 +115,7 @@ export default function Root({ loaderData }: Route.ComponentProps) {
         <meta property="twitter:creator" content={`@${TWITTER_USERNAME}`} />
         <Meta />
         <Links />
+        <OpenObserveRumConfigScript config={openObserveRum} />
         {layout !== 'admin' && <link rel="stylesheet" href={mainStylesheetUrl} />}
         {layout === 'app' && <AppLinks data={data} />}
       </head>

--- a/web/src/rum.client.ts
+++ b/web/src/rum.client.ts
@@ -1,0 +1,48 @@
+import { openobserveLogs } from '@openobserve/browser-logs';
+import { openobserveRum } from '@openobserve/browser-rum';
+
+import type { OpenObserveRumConfig } from './rum';
+
+let initialized = false;
+
+export function initializeOpenObserveRum(config: OpenObserveRumConfig) {
+  if (initialized) {
+    return;
+  }
+
+  const commonOptions = {
+    clientToken: config.clientToken,
+    site: config.site,
+    organizationIdentifier: config.organizationIdentifier,
+    service: config.service,
+    env: config.environment,
+    version: config.version,
+    apiVersion: 'v1',
+    insecureHTTP: config.insecureHTTP,
+  };
+
+  openobserveRum.init({
+    ...commonOptions,
+    applicationId: config.applicationId,
+    sessionSampleRate: config.sessionSampleRate,
+    sessionReplaySampleRate: config.sessionReplaySampleRate,
+    traceSampleRate: config.traceSampleRate,
+    allowedTracingUrls: [window.location.origin],
+    trackResources: true,
+    trackLongTasks: true,
+    trackUserInteractions: true,
+    defaultPrivacyLevel: 'mask-user-input',
+  });
+
+  openobserveLogs.init({
+    ...commonOptions,
+    sessionSampleRate: config.sessionSampleRate,
+    forwardErrorsToLogs: true,
+  });
+
+  if (config.sessionReplaySampleRate > 0) {
+    openobserveRum.startSessionReplayRecording();
+  }
+
+  initialized = true;
+}

--- a/web/src/rum.server.ts
+++ b/web/src/rum.server.ts
@@ -1,0 +1,82 @@
+import type { OpenObserveRumConfig } from './rum';
+
+const requiredVariables = [
+  'OPENOBSERVE_RUM_APPLICATION_ID',
+  'OPENOBSERVE_RUM_CLIENT_TOKEN',
+  'OPENOBSERVE_RUM_SITE',
+] as const;
+
+function sampleRate(value: string | undefined, fallback: number, variable: string) {
+  if (value === undefined || value === '') {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 100) {
+    throw new Error(`${variable} must be a number between 0 and 100`);
+  }
+
+  return parsed;
+}
+
+function parseSite(value: string) {
+  const url = new URL(value.includes('://') ? value : `https://${value}`);
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('OPENOBSERVE_RUM_SITE must use HTTP or HTTPS');
+  }
+
+  return {
+    site: url.host,
+    insecureHTTP: url.protocol === 'http:',
+  };
+}
+
+export function getOpenObserveRumConfig(
+  environment: NodeJS.ProcessEnv = process.env
+): OpenObserveRumConfig | undefined {
+  const configuredVariables = requiredVariables.filter((variable) => environment[variable]?.trim());
+  if (configuredVariables.length === 0) {
+    return undefined;
+  }
+
+  const missingVariables = requiredVariables.filter((variable) => !environment[variable]?.trim());
+  if (missingVariables.length > 0) {
+    throw new Error(`OpenObserve RUM is missing ${missingVariables.join(', ')}`);
+  }
+
+  const { site, insecureHTTP } = parseSite(environment.OPENOBSERVE_RUM_SITE!);
+
+  return {
+    applicationId: environment.OPENOBSERVE_RUM_APPLICATION_ID!.trim(),
+    clientToken: environment.OPENOBSERVE_RUM_CLIENT_TOKEN!.trim(),
+    site,
+    organizationIdentifier:
+      environment.OPENOBSERVE_RUM_ORGANIZATION_IDENTIFIER?.trim() || 'default',
+    service: environment.OPENOBSERVE_RUM_SERVICE?.trim() || 'web',
+    environment:
+      environment.OPENOBSERVE_RUM_ENVIRONMENT?.trim() ||
+      environment.RAILWAY_ENVIRONMENT_NAME?.trim() ||
+      environment.NODE_ENV?.trim() ||
+      'development',
+    version:
+      environment.OPENOBSERVE_RUM_VERSION?.trim() ||
+      environment.RAILWAY_GIT_COMMIT_SHA?.trim() ||
+      '1.0.0',
+    insecureHTTP,
+    sessionSampleRate: sampleRate(
+      environment.OPENOBSERVE_RUM_SESSION_SAMPLE_RATE,
+      100,
+      'OPENOBSERVE_RUM_SESSION_SAMPLE_RATE'
+    ),
+    sessionReplaySampleRate: sampleRate(
+      environment.OPENOBSERVE_RUM_REPLAY_SAMPLE_RATE,
+      20,
+      'OPENOBSERVE_RUM_REPLAY_SAMPLE_RATE'
+    ),
+    traceSampleRate: sampleRate(
+      environment.OPENOBSERVE_RUM_TRACE_SAMPLE_RATE,
+      100,
+      'OPENOBSERVE_RUM_TRACE_SAMPLE_RATE'
+    ),
+  };
+}

--- a/web/src/rum.ts
+++ b/web/src/rum.ts
@@ -1,0 +1,19 @@
+export interface OpenObserveRumConfig {
+  applicationId: string;
+  clientToken: string;
+  site: string;
+  organizationIdentifier: string;
+  service: string;
+  environment: string;
+  version: string;
+  insecureHTTP: boolean;
+  sessionSampleRate: number;
+  sessionReplaySampleRate: number;
+  traceSampleRate: number;
+}
+
+declare global {
+  interface Window {
+    __OPENOBSERVE_RUM__?: OpenObserveRumConfig;
+  }
+}


### PR DESCRIPTION
## Summary

- add the OpenObserve browser RUM and logs SDKs to the web client
- inject RUM configuration from runtime environment variables without requiring a rebuild
- collect resources, long tasks, user interactions, browser errors, session replays, and same-origin distributed traces
- validate required settings and sampling rates, with RUM disabled when it is not configured
- document local and Railway configuration

## Privacy and sampling

- user input is masked in session replays
- RUM session sampling defaults to 100%
- replay sampling defaults to 20% and can be disabled
- trace sampling defaults to 100%

## Verification

- `pnpm lint`
- `pnpm knip`
- `pnpm test:web`
- `pnpm typecheck`
- `pnpm --filter @highforthis/web build:service`
