### PR TITLE
Add dynamic post artwork collages

### DIFF
--- a/web/src/components/PostArtwork/__tests__/PostArtwork.test.tsx
+++ b/web/src/components/PostArtwork/__tests__/PostArtwork.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import PostArtwork from '#/components/PostArtwork';
+import type { PostArtwork_PostFragment } from '#/types/graphql';
+
+function image(id: string, widths = [300, 640]) {
+  return {
+    __typename: 'ImageUpload' as const,
+    crops: widths.map((width) => ({ fileName: `${id}-${width}.jpg`, width })),
+    destination: 'posts',
+    id,
+  };
+}
+
+function post(editorImageCount: number): PostArtwork_PostFragment {
+  return {
+    editorState: {
+      root: {
+        children: Array.from({ length: editorImageCount }, (_, index) => ({
+          __typename: 'ImageNode' as const,
+          image: image(`editor-${index + 1}`),
+        })),
+      },
+    },
+    featuredMedia: [image('featured')],
+  };
+}
+
+describe('postArtwork', () => {
+  it('builds a collage from the first five unique editor images', () => {
+    const data = post(6);
+    data.editorState?.root?.children?.push(data.editorState.root.children[0]);
+    const { container } = render(<PostArtwork post={data} variant="collage" />);
+    const images = [...container.querySelectorAll('img')];
+
+    expect(images).toHaveLength(5);
+    expect(images.map(({ src }) => src)).toEqual(
+      Array.from(
+        { length: 5 },
+        (_, index) =>
+          `https://storage.googleapis.com/wonderboymusic/posts/editor-${index + 1}-640.jpg`
+      )
+    );
+  });
+
+  it('uses a fanned stack and shows the number of additional images', () => {
+    const { container } = render(<PostArtwork post={post(6)} variant="stack" />);
+
+    expect(container.querySelectorAll('img')).toHaveLength(3);
+    expect(screen.getByText('+3')).toBeInTheDocument();
+  });
+
+  it('falls back to featured media when the editor has no images', () => {
+    const { container } = render(<PostArtwork post={post(0)} variant="collage" />);
+
+    expect(container.querySelector('img')?.src).toBe(
+      'https://storage.googleapis.com/wonderboymusic/posts/featured-640.jpg'
+    );
+  });
+});

--- a/web/src/components/PostArtwork/__tests__/PostArtwork.test.tsx
+++ b/web/src/components/PostArtwork/__tests__/PostArtwork.test.tsx
@@ -28,31 +28,37 @@ function post(editorImageCount: number): PostArtwork_PostFragment {
 }
 
 describe('postArtwork', () => {
-  it('builds a collage from the first five unique editor images', () => {
-    const data = post(6);
+  it('builds a deterministic randomized collage from five unique editor images', () => {
+    const data = post(10);
     data.editorState?.root?.children?.push(data.editorState.root.children[0]);
-    const { container } = render(<PostArtwork post={data} variant="collage" />);
-    const images = [...container.querySelectorAll('img')];
+    const sourcesForSeed = (seed: string) => {
+      const { container, unmount } = render(
+        <PostArtwork post={data} seed={seed} variant="collage" />
+      );
+      const sources = [...container.querySelectorAll('img')].map(({ src }) => src);
+      unmount();
+      return sources;
+    };
+    const sources = sourcesForSeed('page-a');
 
-    expect(images).toHaveLength(5);
-    expect(images.map(({ src }) => src)).toEqual(
-      Array.from(
-        { length: 5 },
-        (_, index) =>
-          `https://storage.googleapis.com/wonderboymusic/posts/editor-${index + 1}-640.jpg`
-      )
-    );
+    expect(sources).toHaveLength(5);
+    expect(new Set(sources).size).toBe(5);
+    expect(sources.every((src) => src.includes('/editor-'))).toBeTruthy();
+    expect(sourcesForSeed('page-a')).toEqual(sources);
+    expect(sourcesForSeed('page-b')).not.toEqual(sources);
   });
 
   it('uses a fanned stack and shows the number of additional images', () => {
-    const { container } = render(<PostArtwork post={post(6)} variant="stack" />);
+    const { container } = render(<PostArtwork post={post(6)} seed="stack-seed" variant="stack" />);
 
     expect(container.querySelectorAll('img')).toHaveLength(3);
     expect(screen.getByText('+3')).toBeInTheDocument();
   });
 
   it('falls back to featured media when the editor has no images', () => {
-    const { container } = render(<PostArtwork post={post(0)} variant="collage" />);
+    const { container } = render(
+      <PostArtwork post={post(0)} seed="fallback-seed" variant="collage" />
+    );
 
     expect(container.querySelector('img')?.src).toBe(
       'https://storage.googleapis.com/wonderboymusic/posts/featured-640.jpg'

--- a/web/src/components/PostArtwork/index.tsx
+++ b/web/src/components/PostArtwork/index.tsx
@@ -17,6 +17,7 @@ interface DisplayImage extends ArtworkImage {
 interface PostArtworkProps {
   className?: string;
   post: PostArtwork_PostFragment;
+  seed: string;
   variant: 'collage' | 'stack';
 }
 
@@ -47,7 +48,22 @@ function displayImages(images: ArtworkImage[], targetWidth: number) {
   });
 }
 
-function postImages(post: PostArtwork_PostFragment, targetWidth: number) {
+function hashString(value: string) {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function randomizeImages(images: DisplayImage[], seed: string) {
+  return images.toSorted(
+    (first, second) => hashString(`${seed}:${first.id}`) - hashString(`${seed}:${second.id}`)
+  );
+}
+
+function postImages(post: PostArtwork_PostFragment, targetWidth: number, seed: string) {
   const editorImages =
     post.editorState?.root?.children?.flatMap((node) => {
       if (node && 'image' in node && node.image) {
@@ -61,8 +77,9 @@ function postImages(post: PostArtwork_PostFragment, targetWidth: number) {
 
   const uniqueEditorImages = [...new Map(editorImages.map((image) => [image.id, image])).values()];
   const images = displayImages(uniqueEditorImages, targetWidth);
+  const preferredImages = images.length > 0 ? images : displayImages(featuredImages, targetWidth);
 
-  return images.length > 0 ? images : displayImages(featuredImages, targetWidth);
+  return randomizeImages(preferredImages, seed);
 }
 
 function Collage({ className, images }: { className?: string; images: DisplayImage[] }) {
@@ -134,8 +151,8 @@ function Stack({ className, images }: { className?: string; images: DisplayImage
   );
 }
 
-export default function PostArtwork({ className, post, variant }: PostArtworkProps) {
-  const images = postImages(post, variant === 'collage' ? 640 : 300);
+export default function PostArtwork({ className, post, seed, variant }: PostArtworkProps) {
+  const images = postImages(post, variant === 'collage' ? 640 : 300, seed);
 
   if (images.length === 0) {
     return null;

--- a/web/src/components/PostArtwork/index.tsx
+++ b/web/src/components/PostArtwork/index.tsx
@@ -1,0 +1,182 @@
+import cn from 'classnames';
+import { gql } from 'graphql-tag';
+
+import type { PostArtwork_PostFragment } from '#/types/graphql';
+import { uploadUrl } from '#/utils/media';
+
+interface ArtworkImage {
+  crops: { fileName: string; width: number }[];
+  destination: string;
+  id: string;
+}
+
+interface DisplayImage extends ArtworkImage {
+  src: string;
+}
+
+interface PostArtworkProps {
+  className?: string;
+  post: PostArtwork_PostFragment;
+  variant: 'collage' | 'stack';
+}
+
+const collageItemClasses = {
+  1: [''],
+  2: ['', ''],
+  3: ['row-span-2', '', ''],
+  4: ['', '', '', ''],
+  5: ['col-span-2 row-span-2', 'col-span-2', 'col-span-2', 'col-span-2', 'col-span-2'],
+} as const;
+
+const stackItemClasses = [
+  'z-30 -rotate-2 group-hover:-translate-x-1 group-hover:-rotate-6',
+  'z-20 translate-x-1 rotate-6 group-hover:translate-x-2 group-hover:rotate-10',
+  'z-10 translate-x-2 rotate-12 group-hover:translate-x-4 group-hover:rotate-16',
+];
+
+function cropUrl(image: ArtworkImage, targetWidth: number) {
+  const crops = [...image.crops].sort((a, b) => a.width - b.width);
+  const crop = crops.find(({ width }) => width >= targetWidth) || crops.at(-1);
+  return crop ? uploadUrl(image.destination, crop.fileName) : undefined;
+}
+
+function displayImages(images: ArtworkImage[], targetWidth: number) {
+  return images.flatMap((image) => {
+    const src = cropUrl(image, targetWidth);
+    return src ? [{ ...image, src }] : [];
+  });
+}
+
+function postImages(post: PostArtwork_PostFragment, targetWidth: number) {
+  const editorImages =
+    post.editorState?.root?.children?.flatMap((node) => {
+      if (node && 'image' in node && node.image) {
+        return [node.image];
+      }
+      return [];
+    }) || [];
+
+  const featuredImages =
+    post.featuredMedia?.flatMap((media) => ('crops' in media ? [media] : [])) || [];
+
+  const uniqueEditorImages = [...new Map(editorImages.map((image) => [image.id, image])).values()];
+  const images = displayImages(uniqueEditorImages, targetWidth);
+
+  return images.length > 0 ? images : displayImages(featuredImages, targetWidth);
+}
+
+function Collage({ className, images }: { className?: string; images: DisplayImage[] }) {
+  const visibleImages = images.slice(0, 5);
+  const count = visibleImages.length as keyof typeof collageItemClasses;
+
+  return (
+    <div
+      className={cn(
+        'grid h-full w-full gap-1 bg-neutral-950',
+        count === 2 && 'grid-cols-2',
+        count === 3 && 'grid-cols-2 grid-rows-2',
+        count === 4 && 'grid-cols-2 grid-rows-2',
+        count === 5 && 'grid-cols-6 grid-rows-2',
+        className
+      )}
+    >
+      {visibleImages.map(({ id, src }, index) => (
+        <div key={id} className={cn('overflow-hidden', collageItemClasses[count][index])}>
+          <img
+            alt=""
+            className="h-full w-full object-cover transition-transform duration-700 group-hover:scale-105"
+            loading={index === 0 ? 'eager' : 'lazy'}
+            src={src}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Stack({ className, images }: { className?: string; images: DisplayImage[] }) {
+  const visibleImages = images.slice(0, 3);
+
+  if (visibleImages.length === 1) {
+    return (
+      <div className={cn('h-28 w-28 shrink-0 overflow-hidden rounded-lg', className)}>
+        <img
+          alt=""
+          className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+          loading="lazy"
+          src={visibleImages[0].src}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('relative h-28 w-28 shrink-0', className)}>
+      {visibleImages.map(({ id, src }, index) => (
+        <img
+          key={id}
+          alt=""
+          className={cn(
+            'dark:border-surface-dark-card absolute inset-2 h-24 w-24 rounded-lg border-2 border-white object-cover shadow-md',
+            'transition-transform duration-500 ease-out',
+            stackItemClasses[index]
+          )}
+          loading="lazy"
+          src={src}
+        />
+      ))}
+      {images.length > visibleImages.length && (
+        <span className="bg-pink absolute right-0 bottom-0 z-40 rounded-full px-1.5 py-0.5 text-[10px] font-bold text-white shadow">
+          +{images.length - visibleImages.length}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export default function PostArtwork({ className, post, variant }: PostArtworkProps) {
+  const images = postImages(post, variant === 'collage' ? 640 : 300);
+
+  if (images.length === 0) {
+    return null;
+  }
+
+  return variant === 'collage' ? (
+    <Collage className={className} images={images} />
+  ) : (
+    <Stack className={className} images={images} />
+  );
+}
+
+PostArtwork.fragments = {
+  post: gql`
+    fragment PostArtwork_post on Post {
+      editorState {
+        root {
+          children {
+            ... on ImageNode {
+              image {
+                crops {
+                  fileName
+                  width
+                }
+                destination
+                id
+              }
+            }
+          }
+        }
+      }
+      featuredMedia {
+        destination
+        id
+        ... on ImageUpload {
+          crops {
+            fileName
+            width
+          }
+        }
+      }
+    }
+  `,
+};

--- a/web/src/routes/home/Latest.tsx
+++ b/web/src/routes/home/Latest.tsx
@@ -2,9 +2,9 @@ import cn from 'classnames';
 import { useTranslation } from 'react-i18next';
 
 import Link from '#/components/Link';
+import PostArtwork from '#/components/PostArtwork';
 import SectionHeader from '#/components/SectionHeader';
-import type { ImageUpload, PostConnection } from '#/types/graphql';
-import { uploadUrl } from '#/utils/media';
+import type { PostConnection } from '#/types/graphql';
 
 function Latest({ posts }: { posts: PostConnection }) {
   const { t } = useTranslation();
@@ -13,9 +13,6 @@ function Latest({ posts }: { posts: PostConnection }) {
   }
 
   const [featured, ...rest] = posts.edges;
-  const featuredCrop = featured.node.featuredMedia
-    ?.map((media) => (media as ImageUpload).crops?.find((c) => c.width === 640 || c.width === 300))
-    .find(Boolean);
 
   return (
     <section>
@@ -36,14 +33,8 @@ function Latest({ posts }: { posts: PostConnection }) {
             'hover:shadow-pink/5 dark:hover:shadow-pink/10 hover:shadow-lg'
           )}
         >
-          <div className="aspect-[4/3] overflow-hidden">
-            {featuredCrop && featured.node.featuredMedia?.[0] && (
-              <img
-                alt=""
-                src={uploadUrl(featured.node.featuredMedia[0].destination, featuredCrop.fileName)}
-                className="h-full w-full object-cover transition-transform duration-700 group-hover:scale-105"
-              />
-            )}
+          <div className="aspect-[4/3] overflow-hidden bg-neutral-950">
+            <PostArtwork post={featured.node} variant="collage" />
             <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
           </div>
           <div className="absolute right-0 bottom-0 left-0 p-8">
@@ -64,10 +55,6 @@ function Latest({ posts }: { posts: PostConnection }) {
         {/* Secondary posts stack */}
         <div className="flex flex-col gap-4">
           {rest.map(({ node }) => {
-            const crop = node.featuredMedia
-              ?.map((media) => (media as ImageUpload).crops?.find((c) => c.width === 300))
-              .find(Boolean);
-
             return (
               <Link
                 to={`/post/${node.slug}`}
@@ -80,15 +67,7 @@ function Latest({ posts }: { posts: PostConnection }) {
                   'hover:shadow-pink/5 dark:hover:shadow-pink/10 hover:shadow-lg'
                 )}
               >
-                {crop && node.featuredMedia?.[0] && (
-                  <div className="h-28 w-28 flex-shrink-0 overflow-hidden rounded-lg">
-                    <img
-                      alt=""
-                      src={uploadUrl(node.featuredMedia[0].destination, crop.fileName)}
-                      className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
-                    />
-                  </div>
-                )}
+                <PostArtwork post={node} variant="stack" />
                 <div className="flex flex-col justify-center">
                   <h3 className="group-hover:text-pink mb-1.5 text-lg font-semibold transition-colors">
                     {node.title}

--- a/web/src/routes/home/Latest.tsx
+++ b/web/src/routes/home/Latest.tsx
@@ -6,7 +6,12 @@ import PostArtwork from '#/components/PostArtwork';
 import SectionHeader from '#/components/SectionHeader';
 import type { PostConnection } from '#/types/graphql';
 
-function Latest({ posts }: { posts: PostConnection }) {
+interface LatestProps {
+  artworkSeed: string;
+  posts: PostConnection;
+}
+
+function Latest({ artworkSeed, posts }: LatestProps) {
   const { t } = useTranslation();
   if (!posts || posts.edges.length === 0) {
     return null;
@@ -34,7 +39,11 @@ function Latest({ posts }: { posts: PostConnection }) {
           )}
         >
           <div className="aspect-[4/3] overflow-hidden bg-neutral-950">
-            <PostArtwork post={featured.node} variant="collage" />
+            <PostArtwork
+              post={featured.node}
+              seed={`${artworkSeed}:${featured.node.id}`}
+              variant="collage"
+            />
             <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
           </div>
           <div className="absolute right-0 bottom-0 left-0 p-8">
@@ -67,7 +76,7 @@ function Latest({ posts }: { posts: PostConnection }) {
                   'hover:shadow-pink/5 dark:hover:shadow-pink/10 hover:shadow-lg'
                 )}
               >
-                <PostArtwork post={node} variant="stack" />
+                <PostArtwork post={node} seed={`${artworkSeed}:${node.id}`} variant="stack" />
                 <div className="flex flex-col justify-center">
                   <h3 className="group-hover:text-pink mb-1.5 text-lg font-semibold transition-colors">
                     {node.title}

--- a/web/src/routes/home/index.tsx
+++ b/web/src/routes/home/index.tsx
@@ -12,12 +12,14 @@ import type { Route } from './+types';
 import Latest from './Latest';
 
 export async function loader({ request, context }: Route.LoaderArgs) {
-  return query<HomeQuery>({
+  const data = await query<HomeQuery>({
     request,
     context,
     query: homeQuery,
     variables: { cacheKey: 'home-videos', first: 9 },
   });
+
+  return { ...data, artworkSeed: crypto.randomUUID() };
 }
 
 export const clientLoader = createClientCache();
@@ -30,7 +32,7 @@ function Home({ loaderData }: Route.ComponentProps) {
         <Videos videos={loaderData.videos} paginate={false} />
       </section>
       <AccentLine />
-      <Latest posts={loaderData.posts} />
+      <Latest artworkSeed={loaderData.artworkSeed} posts={loaderData.posts} />
     </>
   );
 }

--- a/web/src/routes/home/index.tsx
+++ b/web/src/routes/home/index.tsx
@@ -1,5 +1,6 @@
 import { gql } from 'graphql-tag';
 
+import PostArtwork from '#/components/PostArtwork';
 import SectionHeader, { AccentLine } from '#/components/SectionHeader';
 import Videos from '#/components/Videos';
 import { videosQuery } from '#/components/Videos/graphql';
@@ -46,16 +47,7 @@ const homeQuery = gql`
     posts(first: 5, status: PUBLISH) @cache(key: "latest") {
       edges {
         node {
-          featuredMedia {
-            destination
-            id
-            ... on ImageUpload {
-              crops {
-                fileName
-                width
-              }
-            }
-          }
+          ...PostArtwork_post
           id
           slug
           summary
@@ -65,6 +57,7 @@ const homeQuery = gql`
     }
     ...Videos_videos
   }
+  ${PostArtwork.fragments.post}
   ${videosQuery}
 `;
 

--- a/web/src/routes/post/index.tsx
+++ b/web/src/routes/post/index.tsx
@@ -5,9 +5,9 @@ import type { MetaFunction } from 'react-router';
 
 import { Heading1 } from '#/components/Heading';
 import Link from '#/components/Link';
-import type { ImageUpload, PostEdge, PostsQuery } from '#/types/graphql';
+import PostArtwork from '#/components/PostArtwork';
+import type { PostEdge, PostsQuery } from '#/types/graphql';
 import { createClientCache } from '#/utils/cache';
-import { uploadUrl } from '#/utils/media';
 import query from '#/utils/query';
 import { rootData } from '#/utils/rootData';
 import titleTemplate from '#/utils/title';
@@ -24,19 +24,21 @@ export const meta: MetaFunction = ({ matches }) => {
 };
 
 export async function loader({ request, context }: Route.LoaderArgs) {
-  return query<PostsQuery>({
+  const data = await query<PostsQuery>({
     request,
     context,
     query: postsQuery,
     variables: { first: 50 },
   });
+
+  return { ...data, artworkSeed: crypto.randomUUID() };
 }
 
 export const clientLoader = createClientCache();
 
 export default function Posts({ loaderData }: Route.ComponentProps) {
   const { t } = useTranslation();
-  const { posts } = loaderData;
+  const { artworkSeed, posts } = loaderData;
 
   if (!posts) {
     return null;
@@ -47,10 +49,6 @@ export default function Posts({ loaderData }: Route.ComponentProps) {
       <Heading1 className="mb-8">{t('posts.heading')}</Heading1>
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {posts.edges.map(({ node }: PostEdge) => {
-          const crop = node.featuredMedia
-            ?.map((media) => (media as ImageUpload).crops?.find((c) => c.width === 300))
-            .find(Boolean);
-
           return (
             <Link
               to={`/post/${node.slug}`}
@@ -63,15 +61,9 @@ export default function Posts({ loaderData }: Route.ComponentProps) {
                 'hover:shadow-pink/5 dark:hover:shadow-pink/10 hover:shadow-lg'
               )}
             >
-              {crop && node.featuredMedia?.[0] && (
-                <div className="aspect-[3/2] overflow-hidden">
-                  <img
-                    alt=""
-                    src={uploadUrl(node.featuredMedia[0].destination, crop.fileName)}
-                    className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
-                  />
-                </div>
-              )}
+              <div className="aspect-[3/2] overflow-hidden bg-neutral-950">
+                <PostArtwork post={node} seed={`${artworkSeed}:${node.id}`} variant="collage" />
+              </div>
               <div className="p-4">
                 <h2 className="group-hover:text-pink mb-1.5 text-base font-semibold transition-colors">
                   {node.title}
@@ -95,16 +87,7 @@ const postsQuery = gql`
     posts(first: $first, status: PUBLISH) @cache(key: "posts") {
       edges {
         node {
-          featuredMedia {
-            destination
-            id
-            ... on ImageUpload {
-              crops {
-                fileName
-                width
-              }
-            }
-          }
+          ...PostArtwork_post
           id
           slug
           summary
@@ -113,4 +96,5 @@ const postsQuery = gql`
       }
     }
   }
+  ${PostArtwork.fragments.post}
 `;

--- a/web/src/types/graphql.ts
+++ b/web/src/types/graphql.ts
@@ -1913,7 +1913,16 @@ export type PostsQueryVariables = Exact<{
 }>;
 
 
-export type PostsQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', edges: Array<{ __typename?: 'PostEdge', node: { __typename?: 'Post', id: string, slug: string, summary?: string | null, title: string, featuredMedia?: Array<
+export type PostsQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', edges: Array<{ __typename?: 'PostEdge', node: { __typename?: 'Post', id: string, slug: string, summary?: string | null, title: string, editorState?: { __typename?: 'EditorState', root?: { __typename?: 'ElementNode', children?: Array<
+              | { __typename?: 'CodeNode' }
+              | { __typename?: 'ElementNode' }
+              | { __typename?: 'HeadingNode' }
+              | { __typename?: 'ImageNode', image?: { __typename?: 'ImageUpload', destination: string, id: string, crops: Array<{ __typename?: 'ImageUploadCrop', fileName: string, width: number }> } | null }
+              | { __typename?: 'LinebreakNode' }
+              | { __typename?: 'QuoteNode' }
+              | { __typename?: 'TextNode' }
+              | { __typename?: 'VideoNode' }
+             | null> | null } | null } | null, featuredMedia?: Array<
           | { __typename?: 'AudioUpload', destination: string, id: string }
           | { __typename?: 'FileUpload', destination: string, id: string }
           | { __typename?: 'ImageUpload', destination: string, id: string, crops: Array<{ __typename?: 'ImageUploadCrop', fileName: string, width: number }> }

--- a/web/src/types/graphql.ts
+++ b/web/src/types/graphql.ts
@@ -1273,6 +1273,22 @@ export type TextNodes_LinebreakNodeFragment = { __typename?: 'LinebreakNode', ty
 
 export type TextNodes_TextNodeFragment = { __typename?: 'TextNode', detail?: number | null, format?: number | null, mode?: TextModeType | null, style?: string | null, text?: string | null, textFormat?: number | null, textStyle?: string | null, type?: string | null, version?: number | null };
 
+export type PostArtwork_PostFragment = { __typename?: 'Post', editorState?: { __typename?: 'EditorState', root?: { __typename?: 'ElementNode', children?: Array<
+        | { __typename?: 'CodeNode' }
+        | { __typename?: 'ElementNode' }
+        | { __typename?: 'HeadingNode' }
+        | { __typename?: 'ImageNode', image?: { __typename?: 'ImageUpload', destination: string, id: string, crops: Array<{ __typename?: 'ImageUploadCrop', fileName: string, width: number }> } | null }
+        | { __typename?: 'LinebreakNode' }
+        | { __typename?: 'QuoteNode' }
+        | { __typename?: 'TextNode' }
+        | { __typename?: 'VideoNode' }
+       | null> | null } | null } | null, featuredMedia?: Array<
+    | { __typename?: 'AudioUpload', destination: string, id: string }
+    | { __typename?: 'FileUpload', destination: string, id: string }
+    | { __typename?: 'ImageUpload', destination: string, id: string, crops: Array<{ __typename?: 'ImageUploadCrop', fileName: string, width: number }> }
+    | { __typename?: 'VideoUpload', destination: string, id: string }
+  > | null };
+
 export type Attended_ShowsFragment = { __typename?: 'ShowConnection', edges: Array<{ __typename?: 'ShowEdge', node: { __typename?: 'Show', date: number, id: string, title?: string | null, url?: string | null, artists: Array<{ __typename?: 'Artist', id: string, name: string, slug: string }>, venue: { __typename?: 'Venue', city?: string | null, id: string, name: string, slug: string, state?: string | null } } }> };
 
 export type ShowsGrid_ShowsFragment = { __typename?: 'ShowConnection', edges: Array<{ __typename?: 'ShowEdge', cursor: string, node: { __typename?: 'Show', date: number, id: string, title?: string | null, url?: string | null, artists: Array<{ __typename?: 'Artist', id: string, name: string, slug: string }>, venue: { __typename?: 'Venue', id: string, name: string, slug: string } } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage?: boolean | null } };
@@ -1835,7 +1851,16 @@ export type HomeQueryVariables = Exact<{
 }>;
 
 
-export type HomeQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', edges: Array<{ __typename?: 'PostEdge', node: { __typename?: 'Post', id: string, slug: string, summary?: string | null, title: string, featuredMedia?: Array<
+export type HomeQuery = { __typename?: 'Query', posts?: { __typename?: 'PostConnection', edges: Array<{ __typename?: 'PostEdge', node: { __typename?: 'Post', id: string, slug: string, summary?: string | null, title: string, editorState?: { __typename?: 'EditorState', root?: { __typename?: 'ElementNode', children?: Array<
+              | { __typename?: 'CodeNode' }
+              | { __typename?: 'ElementNode' }
+              | { __typename?: 'HeadingNode' }
+              | { __typename?: 'ImageNode', image?: { __typename?: 'ImageUpload', destination: string, id: string, crops: Array<{ __typename?: 'ImageUploadCrop', fileName: string, width: number }> } | null }
+              | { __typename?: 'LinebreakNode' }
+              | { __typename?: 'QuoteNode' }
+              | { __typename?: 'TextNode' }
+              | { __typename?: 'VideoNode' }
+             | null> | null } | null } | null, featuredMedia?: Array<
           | { __typename?: 'AudioUpload', destination: string, id: string }
           | { __typename?: 'FileUpload', destination: string, id: string }
           | { __typename?: 'ImageUpload', destination: string, id: string, crops: Array<{ __typename?: 'ImageUploadCrop', fileName: string, width: number }> }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -11,4 +11,9 @@ if (process.env.NODE_ENV === 'production') {
 export default defineConfig({
   base: publicPath,
   plugins: [tailwindcss(), reactRouter(), tsconfigPaths()],
+  server: {
+    watch: {
+      ignored: ['**/__tests__/**', '**/*.test.{js,jsx,ts,tsx}'],
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- build randomized artwork collages from images embedded in each post's editor data on the homepage and `/posts`
- display compact fanned image stacks for secondary homepage posts
- randomize image selection on each page load while keeping SSR and hydration consistent
- select suitable image crops, deduplicate editor images, and fall back to featured media
- prevent Vite dev hot reloads when test files or snapshots change
- add component coverage for randomized collages, stacks, crop selection, and fallback behavior

## Validation
- `pnpm lint`
- `pnpm knip`
- `pnpm test:web`
- `pnpm --filter @highforthis/web typecheck`
- `pnpm --filter @highforthis/web build`
- verified SSR output for `/` and `/posts`, including different artwork across page loads
